### PR TITLE
fix: make mobile hook cross-browser and tighten auth types

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -25,7 +25,7 @@ interface UserData {
     address: string
     phone: string
     email: string
-    social_media_links: any
+    social_media_links: Record<string, string>
     latitude: string
     longitude: string
     created_at: string
@@ -60,7 +60,7 @@ export default function DashboardPage() {
           try {
             const data = await fetchWithAuth<UserData>("/api/me/")
             return data
-          } catch (error) {
+          } catch {
             throw new Error("Failed to fetch user data")
           }
         }
@@ -117,7 +117,7 @@ export default function DashboardPage() {
       {/* Welcome Section */}
       <div className="space-y-2">
         <h1 className="text-3xl font-bold text-white">Welcome back, {userData.first_name}!</h1>
-        <p className="text-gray-400">Here's what's happening with your store today.</p>
+          <p className="text-gray-400">Here&apos;s what&apos;s happening with your store today.</p>
       </div>
 
       {/* Stats Grid */}

--- a/src/app/loginStore/page.tsx
+++ b/src/app/loginStore/page.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Loader2, Eye, EyeOff, Store, User } from "lucide-react"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type { AxiosError } from "axios"
 
 export default function LoginPage() {
   const [loginType, setLoginType] = useState<"store" | "customer">("store")
@@ -60,8 +61,9 @@ export default function LoginPage() {
       localStorage.setItem("refresh_token", data.data.refresh)
 
       router.push("/dashboard")
-    } catch (error: any) {
-      setError(error?.response?.data?.message || "Login failed. Please check your credentials.")
+    } catch (error: unknown) {
+      const err = error as AxiosError<{ message?: string }>
+      setError(err.response?.data?.message || "Login failed. Please check your credentials.")
     } finally {
       setIsLoading(false)
     }

--- a/src/app/registerStore/page.tsx
+++ b/src/app/registerStore/page.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Loader2, Eye, EyeOff } from "lucide-react"
+import type { AxiosError } from "axios"
 
 export default function RegisterPage() {
   const [formData, setFormData] = useState({
@@ -59,8 +60,9 @@ export default function RegisterPage() {
         password: "",
         confirm_password: "",
       })
-    } catch (error: any) {
-      setError(error?.response?.data?.message || "Registration failed. Please try again.")
+    } catch (error: unknown) {
+      const err = error as AxiosError<{ message?: string }>
+      setError(err.response?.data?.message || "Registration failed. Please try again.")
     } finally {
       setIsLoading(false)
     }

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -7,12 +7,26 @@ export function useIsMobile() {
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    const onChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches)
     }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
+
+    // Support older browsers that use addListener/removeListener
+    if (mql.addEventListener) {
+      mql.addEventListener("change", onChange)
+    } else {
+      mql.addListener(onChange)
+    }
+
+    setIsMobile(mql.matches)
+
+    return () => {
+      if (mql.removeEventListener) {
+        mql.removeEventListener("change", onChange)
+      } else {
+        mql.removeListener(onChange)
+      }
+    }
   }, [])
 
   return !!isMobile


### PR DESCRIPTION
## Summary
- support older browsers in useIsMobile by falling back to legacy media query listeners
- tighten auth and page error handling by replacing `any` with typed Axios errors and clarifying data shapes

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_689195021cbc833186d1a5a4e24871c7