### PR TITLE
fix: improve mobile store preview layout

### DIFF
--- a/src/app/_components/previewModel/customer_view_mobile.tsx
+++ b/src/app/_components/previewModel/customer_view_mobile.tsx
@@ -1,10 +1,10 @@
 "use client";
 import { useState, useEffect } from "react";
-import { Input } from "@/components/ui/input"
-import { Search } from "lucide-react"
+import { Input } from "@/components/ui/input";
+import { Search } from "lucide-react";
 import CustomerProductCard from "./productCard";
 
-// Gaming store inventory data
+// Gaming store inventory data (same as in web view)
 const gamingProducts = [
   {
     id: 1,
@@ -150,20 +150,16 @@ const gamingProducts = [
     sku: "CTL-PS5-DS",
     status: "In Stock",
   },
-]
+];
 
-
-export default function CustomerStoreView({ isMobile = false, pattern }: { isMobile?: boolean; pattern: number[] }) {
-  const organizeProductsIntoRows = (
-    products: typeof gamingProducts,
-    isMobile = false
-  ) => {
+export default function CustomerMobileView() {
+  const organizeProductsIntoRows = (products: typeof gamingProducts) => {
     const rows = [];
     let currentIndex = 0;
-    const currentPattern = isMobile ? [1] : pattern;
+    const pattern = [1];
 
     while (currentIndex < products.length) {
-      for (const count of currentPattern) {
+      for (const count of pattern) {
         if (currentIndex >= products.length) break;
         const rowProducts = products.slice(currentIndex, currentIndex + count);
         rows.push({ count, products: rowProducts });
@@ -173,51 +169,50 @@ export default function CustomerStoreView({ isMobile = false, pattern }: { isMob
     return rows;
   };
 
-   const[searchTerm, setSearchTerm] = useState("");
-  const[filteredProducts, setFilteredProducts] = useState(gamingProducts);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [filteredProducts, setFilteredProducts] = useState(gamingProducts);
 
   useEffect(() => {
-    const filtered = gamingProducts.filter(product => {
-    const term = searchTerm.toLowerCase();
-    return (
-      product.name.toLowerCase().includes(term) ||
-      product.category.toLowerCase().includes(term) ||
-      product.sku?.toLowerCase().includes(term)
-    );
-  });
-  setFilteredProducts(filtered);
-    
+    const filtered = gamingProducts.filter((product) => {
+      const term = searchTerm.toLowerCase();
+      return (
+        product.name.toLowerCase().includes(term) ||
+        product.category.toLowerCase().includes(term) ||
+        product.sku?.toLowerCase().includes(term)
+      );
+    });
+    setFilteredProducts(filtered);
   }, [searchTerm]);
 
   return (
-    <div className={`w-full h-full bg-muted ${isMobile ? "w-full" : ""}`}>
-      <div className={`${isMobile ? "max-w-sm" : "max-w-7xl"} mx-auto p-6`}>
+    <div className="w-full h-full bg-muted">
+      <div className="max-w-sm mx-auto p-6">
         <header className="mb-8">
           <div className="text-center mb-6">
-            <h1 className={`${isMobile ? "text-2xl" : "text-4xl"} font-bold text-foreground mb-2`}>GameZone Store</h1>
+            <h1 className="text-2xl font-bold text-foreground mb-2">GameZone Store</h1>
             <p className="text-muted-foreground">Premium Gaming Equipment & Accessories</p>
           </div>
           <div className="relative max-w-md mx-auto mb-6">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" />
-            <Input type="text" placeholder="Search products..." className="pl-10 pr-4 py-2 w-full" 
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}/>
+            <Input
+              type="text"
+              placeholder="Search products..."
+              className="pl-10 pr-4 py-2 w-full"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+            />
           </div>
         </header>
 
         <div className="space-y-6">
-          {organizeProductsIntoRows(filteredProducts, isMobile).map((row, rowIndex) => (
-            <div
-              key={rowIndex}
-              className={`grid gap-4 ${isMobile ? "grid-cols-1" : ""}`}
-              style={!isMobile ? { gridTemplateColumns: `repeat(${row.count}, 1fr)` } : {}}
-            >
+          {organizeProductsIntoRows(filteredProducts).map((row, rowIndex) => (
+            <div key={rowIndex} className="grid gap-4 grid-cols-1">
               {row.products.map((product) => (
                 <CustomerProductCard
                   key={product.id}
                   product={product}
-                  columnSpan={isMobile ? 1 : row.count}
-                  isMobile={isMobile}
+                  columnSpan={1}
+                  isMobile
                 />
               ))}
             </div>
@@ -227,3 +222,4 @@ export default function CustomerStoreView({ isMobile = false, pattern }: { isMob
     </div>
   );
 }
+

--- a/src/app/_components/previewModel/customer_view_web.tsx
+++ b/src/app/_components/previewModel/customer_view_web.tsx
@@ -1,0 +1,230 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import { Search } from "lucide-react";
+import CustomerProductCard from "./productCard";
+
+// Gaming store inventory data
+const gamingProducts = [
+  {
+    id: 1,
+    name: "ASUS ROG Strix RTX 4090",
+    price: 1599.99,
+    category: "Graphics Cards",
+    stock: 12,
+    rating: 4.9,
+    image: "/placeholder.svg?height=300&width=400&text=RTX+4090",
+    description: "High-end gaming graphics card with 24GB GDDR6X memory.",
+    sku: "GPU-RTX4090-001",
+    status: "In Stock",
+  },
+  {
+    id: 2,
+    name: "Razer DeathAdder V3 Pro",
+    price: 149.99,
+    category: "Gaming Mice",
+    stock: 45,
+    rating: 4.8,
+    image: "/placeholder.svg?height=300&width=400&text=Gaming+Mouse",
+    description: "Wireless gaming mouse with Focus Pro 30K sensor.",
+    sku: "MSE-RZR-DA3P",
+    status: "In Stock",
+  },
+  {
+    id: 3,
+    name: "SteelSeries Apex Pro TKL",
+    price: 199.99,
+    category: "Gaming Keyboards",
+    stock: 23,
+    rating: 4.7,
+    image: "/placeholder.svg?height=300&width=400&text=Gaming+Keyboard",
+    description: "Mechanical gaming keyboard with adjustable switches.",
+    sku: "KBD-SS-APTK",
+    status: "In Stock",
+  },
+  {
+    id: 4,
+    name: "HyperX Cloud Alpha S",
+    price: 129.99,
+    category: "Gaming Headsets",
+    stock: 8,
+    rating: 4.6,
+    image: "/placeholder.svg?height=300&width=400&text=Gaming+Headset",
+    description: "7.1 surround sound gaming headset with dual chamber drivers.",
+    sku: "HDS-HX-CAS",
+    status: "Low Stock",
+  },
+  {
+    id: 5,
+    name: "Corsair K95 RGB Platinum",
+    price: 199.99,
+    category: "Gaming Keyboards",
+    stock: 0,
+    rating: 4.5,
+    image: "/placeholder.svg?height=300&width=400&text=RGB+Keyboard",
+    description: "Premium mechanical gaming keyboard with Cherry MX switches.",
+    sku: "KBD-COR-K95",
+    status: "Out of Stock",
+  },
+  {
+    id: 6,
+    name: "NVIDIA GeForce RTX 4070",
+    price: 599.99,
+    category: "Graphics Cards",
+    stock: 18,
+    rating: 4.7,
+    image: "/placeholder.svg?height=300&width=400&text=RTX+4070",
+    description: "Mid-range gaming GPU with excellent 1440p performance.",
+    sku: "GPU-NV-4070",
+    status: "In Stock",
+  },
+  {
+    id: 7,
+    name: "Logitech G Pro X Superlight",
+    price: 149.99,
+    category: "Gaming Mice",
+    stock: 31,
+    rating: 4.8,
+    image: "/placeholder.svg?height=300&width=400&text=Pro+Gaming+Mouse",
+    description: "Ultra-lightweight wireless gaming mouse for esports.",
+    sku: "MSE-LOG-GPXS",
+    status: "In Stock",
+  },
+  {
+    id: 8,
+    name: "AMD Ryzen 9 7900X",
+    price: 549.99,
+    category: "Processors",
+    stock: 15,
+    rating: 4.8,
+    image: "/placeholder.svg?height=300&width=400&text=AMD+Processor",
+    description: "12-core, 24-thread processor for high-end gaming builds.",
+    sku: "CPU-AMD-R97X",
+    status: "In Stock",
+  },
+  {
+    id: 9,
+    name: "ASUS ROG Swift PG279QM",
+    price: 699.99,
+    category: "Gaming Monitors",
+    stock: 6,
+    rating: 4.9,
+    image: "/placeholder.svg?height=300&width=400&text=Gaming+Monitor",
+    description: "27-inch 1440p 240Hz gaming monitor with G-Sync.",
+    sku: "MON-AS-PG279",
+    status: "Low Stock",
+  },
+  {
+    id: 10,
+    name: "Corsair Vengeance RGB Pro",
+    price: 159.99,
+    category: "Memory",
+    stock: 42,
+    rating: 4.6,
+    image: "/placeholder.svg?height=300&width=400&text=RGB+Memory",
+    description: "32GB (2x16GB) DDR4-3200 RGB gaming memory kit.",
+    sku: "RAM-COR-VRGB",
+    status: "In Stock",
+  },
+  {
+    id: 11,
+    name: "Xbox Wireless Controller",
+    price: 59.99,
+    category: "Controllers",
+    stock: 67,
+    rating: 4.5,
+    image: "/placeholder.svg?height=300&width=400&text=Xbox+Controller",
+    description: "Official Xbox wireless controller for PC and Xbox.",
+    sku: "CTL-XBX-WRL",
+    status: "In Stock",
+  },
+  {
+    id: 12,
+    name: "PlayStation 5 DualSense",
+    price: 69.99,
+    category: "Controllers",
+    stock: 34,
+    rating: 4.7,
+    image: "/placeholder.svg?height=300&width=400&text=PS5+Controller",
+    description: "PS5 DualSense wireless controller with haptic feedback.",
+    sku: "CTL-PS5-DS",
+    status: "In Stock",
+  },
+]
+
+
+export default function CustomerWebView({ pattern }: { pattern: number[] }) {
+  const organizeProductsIntoRows = (
+    products: typeof gamingProducts,
+    viewPattern: number[]
+  ) => {
+    const rows = [];
+    let currentIndex = 0;
+
+    while (currentIndex < products.length) {
+      for (const count of viewPattern) {
+        if (currentIndex >= products.length) break;
+        const rowProducts = products.slice(currentIndex, currentIndex + count);
+        rows.push({ count, products: rowProducts });
+        currentIndex += count;
+      }
+    }
+    return rows;
+  };
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [filteredProducts, setFilteredProducts] = useState(gamingProducts);
+
+  useEffect(() => {
+    const filtered = gamingProducts.filter((product) => {
+      const term = searchTerm.toLowerCase();
+      return (
+        product.name.toLowerCase().includes(term) ||
+        product.category.toLowerCase().includes(term) ||
+        product.sku?.toLowerCase().includes(term)
+      );
+    });
+    setFilteredProducts(filtered);
+  }, [searchTerm]);
+
+  return (
+    <div className="w-full h-full bg-muted">
+      <div className="max-w-7xl mx-auto p-6">
+        <header className="mb-8">
+          <div className="text-center mb-6">
+            <h1 className="text-4xl font-bold text-foreground mb-2">GameZone Store</h1>
+            <p className="text-muted-foreground">Premium Gaming Equipment & Accessories</p>
+          </div>
+          <div className="relative max-w-md mx-auto mb-6">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="text"
+              placeholder="Search products..."
+              className="pl-10 pr-4 py-2 w-full"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+            />
+          </div>
+        </header>
+
+        <div className="space-y-6">
+          {organizeProductsIntoRows(filteredProducts, pattern).map((row, rowIndex) => (
+            <div
+              key={rowIndex}
+              className="grid gap-4"
+              style={{ gridTemplateColumns: `repeat(${row.count}, 1fr)` }}
+            >
+              {row.products.map((product) => (
+                <CustomerProductCard
+                  key={product.id}
+                  product={product}
+                  columnSpan={row.count}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/previewModel/store_preview_modal.tsx
+++ b/src/app/_components/previewModel/store_preview_modal.tsx
@@ -1,10 +1,11 @@
 "use client"
 
 
-import { Button } from "@/components/ui/button"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { X } from "lucide-react"
-import CustomerStoreView from "./customer_view_layout"
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { X } from "lucide-react";
+import CustomerWebView from "./customer_view_web";
+import CustomerMobileView from "./customer_view_mobile";
 
 
 interface StorePreviewModalProps {
@@ -32,12 +33,12 @@ export default function StorePreviewModal({ isOpen, onClose, selectedView, patte
         <div className="flex-1 overflow-hidden bg-muted">
           {selectedView === "web" ? (
             <div className="h-full overflow-auto">
-              <CustomerStoreView pattern={pattern} />
+              <CustomerWebView pattern={pattern} />
             </div>
           ) : (
-            <div className="h-full flex justify-center items-start pt-8 overflow-auto">
-              <div className="w-96 h-full bg-white rounded-lg shadow-xl overflow-auto">
-                <CustomerStoreView isMobile={true} pattern={pattern} />
+            <div className="h-full flex justify-center items-start pt-8 overflow-hidden">
+              <div className="w-full max-w-sm h-full bg-white rounded-lg shadow-xl overflow-y-auto">
+                <CustomerMobileView />
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- improve mobile store preview layout by using responsive width constraints
- prevent mobile preview overflow by isolating scroll behavior
- split store preview into dedicated mobile and web layouts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `'` can be escaped with `&apos;`, `Unexpected any`, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6895a670b5ec8331959a4b51d79352a4