### PR TITLE
Support multiple stores from API

### DIFF
--- a/src/app/dashboard/layoutPreview/page.tsx
+++ b/src/app/dashboard/layoutPreview/page.tsx
@@ -26,7 +26,7 @@ interface PaginatedResponse<T> {
 }
 
 export default function StoreLayoutPreview() {
-  const storeId = useAppSelector((state) => state.userData.store?.id)
+  const storeId = useAppSelector((state) => state.userData.stores[0]?.id)
 
   const [layouts, setLayouts] = useState<LayoutResponse[]>([])
   const [selectedLayoutId, setSelectedLayoutId] = useState<number | undefined>(undefined)

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,15 +6,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Eye, MousePointer, ShoppingCart, Users, TrendingUp, Calendar } from "lucide-react"
-import { useDispatch, useSelector } from "react-redux"
-import { AppDispatch, RootState } from "@/redux/store"
-import { getUser } from "@/redux/actions/user_api/getUserData"
+import { useSelector } from "react-redux"
+import { RootState } from "@/redux/store"
 
 export default function DashboardPage() {
-  const dispatch = useDispatch<AppDispatch>()
-  const { user, store, loading, error } = useSelector(
+  const { user, stores, loading, error } = useSelector(
     (state: RootState) => state.userData
   )
+  const store = stores[0]
 
 
   if (loading) {

--- a/src/app/dashboard/settingPage/storeInfo/page.tsx
+++ b/src/app/dashboard/settingPage/storeInfo/page.tsx
@@ -14,7 +14,7 @@ const storeTypes = ["DEPT", "SUPER", "LOCAL", "ONLINE"];
 
 export default function StoreRegistrationPage() {
   const user = useSelector((state: RootState) => state.userData.user);
-  const store = useSelector((state: RootState) => state.userData.store);
+  const store = useSelector((state: RootState) => state.userData.stores[0]);
   const [form, setForm] = useState({
     name: store?.name || "",
     store_type: store?.store_type || "",

--- a/src/app/dashboard/storeMgmt/page.tsx
+++ b/src/app/dashboard/storeMgmt/page.tsx
@@ -10,7 +10,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 
 const StoreManager = () => {
 
-  const store = useSelector((state: RootState) => state.userData.store)
+  const stores = useSelector((state: RootState) => state.userData.stores)
   return (
      <div className="p-6">
       <div className="flex justify-between items-center mb-4">
@@ -20,24 +20,27 @@ const StoreManager = () => {
         </Link>
       </div>
 
-      
-      {store ? (
-        <Card className="max-w-md mx-auto">
-          <CardContent className="text-center">
-            <Avatar className="h-16 w-16 mx-auto">
-              <AvatarImage src={store.logo} alt={store.name} />
-              <AvatarFallback>
-                {store.name.substring(0, 2).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
-            <p className="mt-4 text-white">{store.name}</p>
-          </CardContent>
-          <CardFooter className="flex justify-center">
-            <Button asChild variant="outline">
-              <Link href="/dashboard/storeMgmt/registerStore">Edit Store</Link>
-            </Button>
-          </CardFooter>
-        </Card>
+      {stores.length > 0 ? (
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {stores.map((store) => (
+            <Card key={store.id} className="max-w-md mx-auto">
+              <CardContent className="text-center">
+                <Avatar className="h-16 w-16 mx-auto">
+                  <AvatarImage src={store.logo} alt={store.name} />
+                  <AvatarFallback>
+                    {store.name.substring(0, 2).toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <p className="mt-4 text-white">{store.name}</p>
+              </CardContent>
+              <CardFooter className="flex justify-center">
+                <Button asChild variant="outline">
+                  <Link href="/dashboard/storeMgmt/registerStore">Edit Store</Link>
+                </Button>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
       ) : (
         <p className="text-center text-white">No store data available.</p>
       )}

--- a/src/app/dashboard/storeMgmt/registerStore/page.tsx
+++ b/src/app/dashboard/storeMgmt/registerStore/page.tsx
@@ -1,4 +1,3 @@
-//#TODO: To make store an array of object
 "use client";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
@@ -16,7 +15,7 @@ const storeTypes = ["DEPT", "SUPER", "LOCAL", "ONLINE"];
 
 export default function StoreRegistrationPage() {
   const user = useSelector((state: RootState) => state.userData.user);
-  const store = useSelector((state: RootState) => state.userData.store);
+  const store = useSelector((state: RootState) => state.userData.stores[0]);
 
   // Access the toast function
   const { addToast } = useToast();

--- a/src/model/userState.ts
+++ b/src/model/userState.ts
@@ -3,7 +3,7 @@ import { GetStoreData } from "./store"
 
 export interface UserState {
   user: GetUserData | null
-  store: GetStoreData | null
+  stores: GetStoreData[]
   accessToken: string | null
   refreshToken: string | null
   isAuthenticated: boolean

--- a/src/redux/features/userData/userSlice.ts
+++ b/src/redux/features/userData/userSlice.ts
@@ -8,7 +8,7 @@ import { MeApiResponse } from "../../../model/meApiResponse";
 
 const initialState: UserState = {
   user: null,
-  store: null,
+  stores: [],
   accessToken: null,
   refreshToken: null,
   isAuthenticated: false,
@@ -22,7 +22,7 @@ const userSlice = createSlice({
   reducers: {
     "resetUserState": (state) => {
       state.user = null;
-      state.store = null,
+      state.stores = [];
       state.loading = false;
       state.error = null;
     }
@@ -74,6 +74,7 @@ const userSlice = createSlice({
         state.accessToken = null;
         state.refreshToken = null;
         state.isAuthenticated = false;
+        state.stores = [];
       })
       .addCase(logoutUser.rejected, (state, action) => {
         state.loading = false;
@@ -92,7 +93,7 @@ const userSlice = createSlice({
           state.loading = false
           const { store, ...userData } = action.payload
           state.user = userData
-          state.store = store !== undefined ? store : null
+          state.stores = Array.isArray(store) ? store : []
           state.isAuthenticated = true
         }
       )


### PR DESCRIPTION
## Summary
- Represent user stores as an array in the Redux state
- Update dashboard and settings pages to consume the stores array and show multiple stores in management
- Adjust layout preview and registration flows to read the first store from the list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: see log)*

------
https://chatgpt.com/codex/tasks/task_b_6899bfc99b1c83318cbc60a90179e181