### PR TITLE
Add dashboard analytics overview for multiple stores

### DIFF
--- a/src/app/_components/dashboardComp/store-analytics-overview.tsx
+++ b/src/app/_components/dashboardComp/store-analytics-overview.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+interface StoreAnalytics {
+  id: number
+  name: string
+  views?: number
+  clicks_on_discounts?: number
+  orders_received?: number
+  followers?: unknown[]
+}
+
+interface StoreAnalyticsOverviewProps {
+  stores: StoreAnalytics[]
+}
+
+export function StoreAnalyticsOverview({ stores }: StoreAnalyticsOverviewProps) {
+  return (
+    <Card className="bg-gray-900 border-gray-800">
+      <CardHeader>
+        <CardTitle className="text-white">Store Analytics Overview</CardTitle>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        <table className="min-w-full text-left text-sm">
+          <thead>
+            <tr className="text-gray-400">
+              <th className="px-4 py-2">Store</th>
+              <th className="px-4 py-2">Views</th>
+              <th className="px-4 py-2">Discount Clicks</th>
+              <th className="px-4 py-2">Orders</th>
+              <th className="px-4 py-2">Followers</th>
+            </tr>
+          </thead>
+          <tbody>
+            {stores.map((store) => (
+              <tr key={store.id} className="border-t border-gray-800">
+                <td className="px-4 py-2 text-white">{store.name}</td>
+                <td className="px-4 py-2 text-white">{(store.views ?? 0).toLocaleString()}</td>
+                <td className="px-4 py-2 text-white">{(store.clicks_on_discounts ?? 0).toLocaleString()}</td>
+                <td className="px-4 py-2 text-white">{(store.orders_received ?? 0).toLocaleString()}</td>
+                <td className="px-4 py-2 text-white">{(store.followers?.length ?? 0).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { StatsCard } from "@/app/_components/dashboardComp/stats-card"
 import { StoreInfoCard } from "@/app/_components/dashboardComp/store-info-card"
+import { StoreAnalyticsOverview } from "@/app/_components/dashboardComp/store-analytics-overview"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -13,7 +14,21 @@ export default function DashboardPage() {
   const { user, stores, loading, error } = useSelector(
     (state: RootState) => state.userData
   )
-  const store = stores[0]
+  const primaryStore = stores[0]
+
+  const totalViews = stores.reduce((sum, s) => sum + (s.views ?? 0), 0)
+  const totalDiscountClicks = stores.reduce(
+    (sum, s) => sum + (s.clicks_on_discounts ?? 0),
+    0
+  )
+  const totalOrders = stores.reduce(
+    (sum, s) => sum + (s.orders_received ?? 0),
+    0
+  )
+  const totalFollowers = stores.reduce(
+    (sum, s) => sum + (s.followers?.length ?? 0),
+    0
+  )
 
 
   if (loading) {
@@ -38,15 +53,14 @@ export default function DashboardPage() {
     )
   }
 
-  const views = store?.views ?? 0
-  const discountClicks = store?.clicks_on_discounts ?? 0
-  const orders = store?.orders_received ?? 0
-  const followersCount = store?.followers?.length ?? 0
-  const storeType = store?.store_type ?? "N/A"
-  const businessId = store?.business_registration_number ?? "N/A"
-  const isVerified = store?.is_verified ?? false
-  const createdDate = store?.created_at
-    ? new Date(store.created_at).toLocaleDateString()
+  const views = primaryStore?.views ?? 0
+  const discountClicks = primaryStore?.clicks_on_discounts ?? 0
+  const orders = primaryStore?.orders_received ?? 0
+  const storeType = primaryStore?.store_type ?? "N/A"
+  const businessId = primaryStore?.business_registration_number ?? "N/A"
+  const isVerified = primaryStore?.is_verified ?? false
+  const createdDate = primaryStore?.created_at
+    ? new Date(primaryStore.created_at).toLocaleDateString()
     : "N/A"
 
   return (
@@ -54,22 +68,27 @@ export default function DashboardPage() {
       {/* Welcome Section */}
       <div className="space-y-2">
         <h1 className="text-3xl font-bold text-white">Welcome back, {user.first_name}!</h1>
-        <p className="text-gray-400">Here's what's happening with your store today.</p>
+        <p className="text-gray-400">Here&apos;s what&apos;s happening with your store today.</p>
       </div>
 
       {/* Stats Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <StatsCard title="Total Views" value={views} icon={Eye} description="Store profile views" trend={{ value: 12, isPositive: true }} />
-        <StatsCard title="Discount Clicks" value={discountClicks} icon={MousePointer} description="Clicks on your deals" trend={{ value: 8, isPositive: true }} />
-        <StatsCard title="Orders Received" value={orders} icon={ShoppingCart} description="Total orders" trend={{ value: 15, isPositive: true }} />
-        <StatsCard title="Followers" value={followersCount} icon={Users} description="Store followers" trend={{ value: 5, isPositive: true }} />
+        <StatsCard title="Total Views" value={totalViews} icon={Eye} description="Store profile views" trend={{ value: 12, isPositive: true }} />
+        <StatsCard title="Discount Clicks" value={totalDiscountClicks} icon={MousePointer} description="Clicks on your deals" trend={{ value: 8, isPositive: true }} />
+        <StatsCard title="Orders Received" value={totalOrders} icon={ShoppingCart} description="Total orders" trend={{ value: 15, isPositive: true }} />
+        <StatsCard title="Followers" value={totalFollowers} icon={Users} description="Store followers" trend={{ value: 5, isPositive: true }} />
       </div>
+
+      {/* Stores Overview */}
+      {stores.length > 0 && (
+        <StoreAnalyticsOverview stores={stores} />
+      )}
 
       {/* Store Information and Quick Actions */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">
-          {store ? (
-            <StoreInfoCard store={store} />
+          {primaryStore ? (
+            <StoreInfoCard store={primaryStore} />
           ) : (
             <Card className="bg-gray-900 border-gray-800 p-4 text-white">
               <p>No store data found for this account.</p>

--- a/src/app/dashboard/storeMgmt/page.tsx
+++ b/src/app/dashboard/storeMgmt/page.tsx
@@ -40,49 +40,53 @@ const StoreManager = () => {
       {stores.length > 0 ? (
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {stores.map((store) => (
+            <Card
+              key={store.id}
+              className="w-full bg-gray-900 border-gray-800 hover:border-gray-700 transition-colors flex flex-col h-full"
+            >
+              <CardHeader className="items-center text-center pb-0">
+                <Avatar className="h-16 w-16 mb-3">
+                  <AvatarImage
+                    src={store.logo || undefined}
+                    alt={store.name}
+                    className="object-cover"
+                    onError={(e) => ((e.target as HTMLImageElement).style.display = "none")}
+                  />
+                  <AvatarFallback className="bg-emerald-600 text-white">
+                    {(store?.name ?? "").substring(0, 2).toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
 
-      <Card key={store.id} className="max-w-md mx-auto">
-      <CardHeader className="text-center">
-          <Avatar className="h-16 w-16 mx-auto">
-            <AvatarImage
-        src={store.logo || undefined}
-        onError={(e) => ((e.target as HTMLImageElement).style.display = "none")}
-      />
-      <AvatarFallback>
-        {(store?.name ?? "").substring(0, 2).toUpperCase()}
-      </AvatarFallback>
-    </Avatar>
+                <CardTitle className="text-white text-xl">{store.name}</CardTitle>
+                <CardDescription className="mt-1">
+                  <Badge
+                    variant="secondary"
+                    className="bg-emerald-900 text-emerald-200 text-xs"
+                  >
+                    {storeTypeLabels[store.store_type] || store.store_type}
+                  </Badge>
+                </CardDescription>
+              </CardHeader>
 
-    <div>
-      <CardTitle className="text-white">{store.name}</CardTitle>
-      <CardDescription>
-        <Badge variant="secondary" className="text-xs">
-          {storeTypeLabels[store.store_type] || store.store_type}
-        </Badge>
-      </CardDescription>
-    </div>
-  </CardHeader>
+              <CardContent className="space-y-2 text-sm text-gray-300 flex-1">
+                <div className="flex items-center gap-2">
+                  <MapPin className="h-4 w-4 text-emerald-400" />
+                  <span>
+                    {store.city}, {store.district}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Phone className="h-4 w-4 text-emerald-400" />
+                  <span>{store.phone}</span>
+                </div>
+              </CardContent>
 
-  <CardContent className="text-sm text-gray-300 space-y-2">
-    <div className="flex items-center gap-2">
-      <MapPin className="h-4 w-4" />
-      <span>
-        {store.city}, {store.district}
-      </span>
-    </div>
-    <div className="flex items-center gap-2">
-      <Phone className="h-4 w-4" />
-      <span>{store.phone}</span>
-    </div>
-  </CardContent>
-
-  <CardFooter className="flex justify-end">
-    <Button asChild variant="outline">
-      <Link href="/dashboard/storeMgmt/registerStore">Manage</Link>
-    </Button>
-  </CardFooter>
-</Card>
-
+              <CardFooter className="pt-4">
+                <Button asChild variant="outline" className="w-full">
+                  <Link href="/dashboard/storeMgmt/registerStore">Manage</Link>
+                </Button>
+              </CardFooter>
+            </Card>
           ))}
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- aggregate views, clicks, orders, and followers across all stores
- show per-store metrics in a new dashboard overview table

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_689acbcc360c8331873af5bbb4e56809